### PR TITLE
Bump base version

### DIFF
--- a/lucid-svg.cabal
+++ b/lucid-svg.cabal
@@ -19,7 +19,7 @@ library
                        Lucid.Svg.Path,
                        Lucid.Svg.Elements,
                        Lucid.Svg.Attributes
-  build-depends:       base          >= 4.5   && <= 4.10,
+  build-depends:       base          >= 4.5   && <= 4.12,
                        blaze-builder >= 0.2   && < 0.5,
                        transformers  >= 0.2   && < 0.6,
                        text          >= 0.11  && < 1.3,


### PR DESCRIPTION
This allows usage with GHC 4.6 and current Stack lts resolvers.